### PR TITLE
add missing require

### DIFF
--- a/test/erc20-distribution-factory/multi-rewards-single-stakable/create-distribution.test.js
+++ b/test/erc20-distribution-factory/multi-rewards-single-stakable/create-distribution.test.js
@@ -1,3 +1,4 @@
+require("../../utils/assertion.js"); 
 const BN = require("bn.js");
 const { expect } = require("chai");
 const { getEvmTimestamp } = require("../../utils/network");

--- a/test/erc20-distribution-factory/single-tokens/create-distribution.test.js
+++ b/test/erc20-distribution-factory/single-tokens/create-distribution.test.js
@@ -1,3 +1,4 @@
+require("../../utils/assertion.js"); 
 const BN = require("bn.js");
 const { expect } = require("chai");
 const { getEvmTimestamp } = require("../../utils/network");

--- a/test/erc20-distribution/multi-rewards-single-stakable/cancelation.test.js
+++ b/test/erc20-distribution/multi-rewards-single-stakable/cancelation.test.js
@@ -1,3 +1,4 @@
+require("../../utils/assertion.js"); 
 const BN = require("bn.js");
 const { expect } = require("chai");
 const { ZERO_BN } = require("../../constants");

--- a/test/erc20-distribution/multi-rewards-single-stakable/claiming.test.js
+++ b/test/erc20-distribution/multi-rewards-single-stakable/claiming.test.js
@@ -1,3 +1,4 @@
+require("../../utils/assertion.js"); 
 const BN = require("bn.js");
 const { expect } = require("chai");
 const { MAXIMUM_VARIANCE, ZERO_BN } = require("../../constants");

--- a/test/erc20-distribution/multi-rewards-single-stakable/initialization.test.js
+++ b/test/erc20-distribution/multi-rewards-single-stakable/initialization.test.js
@@ -1,3 +1,4 @@
+require("../../utils/assertion.js"); 
 const BN = require("bn.js");
 const { expect } = require("chai");
 const { ZERO_ADDRESS } = require("../../constants");

--- a/test/erc20-distribution/multi-rewards-single-stakable/recovering.test.js
+++ b/test/erc20-distribution/multi-rewards-single-stakable/recovering.test.js
@@ -1,3 +1,4 @@
+require("../../utils/assertion.js"); 
 const BN = require("bn.js");
 const { expect } = require("chai");
 const { ZERO_BN } = require("../../constants");

--- a/test/erc20-distribution/single-tokens/cancelation.test.js
+++ b/test/erc20-distribution/single-tokens/cancelation.test.js
@@ -1,3 +1,4 @@
+require("../../utils/assertion.js"); 
 const BN = require("bn.js");
 const { expect } = require("chai");
 const { ZERO_BN } = require("../../constants");

--- a/test/erc20-distribution/single-tokens/claimable-rewards.test.js
+++ b/test/erc20-distribution/single-tokens/claimable-rewards.test.js
@@ -1,3 +1,4 @@
+require("../../utils/assertion.js"); 
 const BN = require("bn.js");
 const { expect } = require("chai");
 const { initializeDistribution } = require("../../utils");

--- a/test/erc20-distribution/single-tokens/claiming.test.js
+++ b/test/erc20-distribution/single-tokens/claiming.test.js
@@ -1,3 +1,4 @@
+require("../../utils/assertion.js"); 
 const BN = require("bn.js");
 const { expect } = require("chai");
 const { MAXIMUM_VARIANCE, ZERO_BN } = require("../../constants");

--- a/test/erc20-distribution/single-tokens/initialization.test.js
+++ b/test/erc20-distribution/single-tokens/initialization.test.js
@@ -1,3 +1,4 @@
+require("../../utils/assertion.js"); 
 const BN = require("bn.js");
 const { expect } = require("chai");
 const { ZERO_ADDRESS } = require("../../constants");

--- a/test/erc20-distribution/single-tokens/recovering.test.js
+++ b/test/erc20-distribution/single-tokens/recovering.test.js
@@ -1,3 +1,4 @@
+require("../../utils/assertion.js"); 
 const BN = require("bn.js");
 const { expect } = require("chai");
 const { ZERO_BN } = require("../../constants");

--- a/test/erc20-distribution/single-tokens/staking.test.js
+++ b/test/erc20-distribution/single-tokens/staking.test.js
@@ -1,3 +1,4 @@
+require("../../utils/assertion.js"); 
 const { expect } = require("chai");
 const {
     initializeDistribution,

--- a/test/erc20-distribution/single-tokens/withdrawing.test.js
+++ b/test/erc20-distribution/single-tokens/withdrawing.test.js
@@ -1,3 +1,4 @@
+require("../../utils/assertion.js"); 
 const BN = require("bn.js");
 const { expect } = require("chai");
 const {


### PR DESCRIPTION
This makes 26 more tests pass, to not have the

AssertionError: expected 'Invalid Chai property: equalBn. Did you mean "equal"?' 

I'm not sure how it's been working for you without it.